### PR TITLE
Update "i2c-bus" dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,12 @@
     "HMC5883L",
     "i2c",
     "compass",
-    "BeagleBone"
+    "BeagleBone",
+    "Raspberry Pi"
   ],
   "author": "Simon Werner",
   "license": "APSL-2.0",
   "dependencies": {
-    "i2c-bus": "^1.0.3"
+    "i2c-bus": "^5.2.2"
   }
 }


### PR DESCRIPTION
Hey, I don't know how active this repository still is but here is a pull request that simply updates the `i2c-bus` dependency to its currently latest version. 

Version 1.x.x of `i2c-bus` was not installable anymore with node 14 on my raspberry pi and as far as I can tell there were no breaking changes that would affect this library ([writeByteSync](https://github.com/fivdi/i2c-bus#buswritebytesyncaddr-cmd-byte) still exists). However, I could only test the example on a raspberry pi, since I have no BeagleBone.

It would be amazing if this fix would make into the npm package but either way thanks for your work :)